### PR TITLE
navigation tab without fancy css

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,26 +1,38 @@
 import React, {Component} from 'react';
 import Login from "./auth/Login";
 import {Register} from "./auth/Register";
-import { Switch, Route, Redirect } from 'react-router-dom';
+import {Switch, Route, Redirect} from 'react-router-dom';
 import UserProfile from "./users/UserProfile";
+import DonorHome from "./donors/DonorHome";
+import NgoHome from "./ngos/NgoHome";
 
 class Main extends Component {
 
     getLogin = () => {
         return this.props.isLoggedIn
-            ? <Redirect to = "/profile"/>
+            ? <Redirect to="/home"/>
             : <Login handleLoginSuccessed={this.props.handleLoginSucceed}/>;
     }
 
-    getProfile = () =>{
-        return this.props.isLoggedIn
-            ? <UserProfile session={this.props.session} handleLogout={this.props.handleLogout}/>
-            : <Redirect to = "/"/>
+    // getProfile = () => {
+    //     return this.props.isLoggedIn
+    //         ? <UserProfile session={this.props.session} handleLogout={this.props.handleLogout}/>
+    //         : <Redirect to="/"/>
+    // }
+
+    getHome = () => {
+        if (this.props.isLoggedIn) {
+            return this.props.session.idToken.payload["custom:custom:NGO"] == 0
+                ? <DonorHome session={this.props.session} handleLogout={this.props.handleLogout}/>
+                : <NgoHome session={this.props.session} handleLogout={this.props.handleLogout}/>
+        } else {
+            return <Redirect to={"/"}/>;
+        }
     }
 
-    getRegister = () =>{
+    getRegister = () => {
         return this.props.isLoggedIn
-            ? <Redirect to = "/profile"/>
+            ? <Redirect to="/home"/>
             : <Register handleLogout={this.props.handleLogout}/>;
     }
 
@@ -30,7 +42,7 @@ class Main extends Component {
                 <Switch>
                     <Route exact path="/register" render={this.getRegister}/>
                     <Route exact path="/" render={this.getLogin}/>
-                    <Route exact path="/profile" render={this.getProfile}/>
+                    <Route exact path="/home" render={this.getHome}/>
                 </Switch>
             </div>
         );

--- a/src/components/donors/DonorHome.js
+++ b/src/components/donors/DonorHome.js
@@ -1,0 +1,71 @@
+import React, {Component} from 'react';
+import {Tabs} from 'antd';
+
+const {TabPane} = Tabs;
+
+class DonorHome extends Component {
+    state = {
+        user_id: this.props.session.idToken.payload["cognito:username"],
+        NGO: this.props.session.idToken.payload["custom:custom:NGO"],
+        address: this.props.session.idToken.payload["address"].formatted,
+        lastName: this.props.session.idToken.payload["family_name"],
+        firstName: this.props.session.idToken.payload["given_name"],
+        phoneNumber: this.props.session.idToken.payload["phone_number"]
+    }
+
+    componentDidMount() {
+        console.log(this.state.firstName);
+        console.log(this.state.lastName);
+        console.log(this.state.user_id);
+        console.log(this.state.NGO);
+        console.log(this.state.address);
+        console.log(this.state.phoneNumber);
+    }
+
+    renderHome = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a donor home page</h2>)
+    }
+
+    renderProfile = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a donor profile page</h2>)
+    }
+
+    renderHistory = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a donor history page</h2>)
+    }
+
+    renderDonateNow = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a donor donate now page</h2>)
+    }
+
+    render() {
+        return (
+            <div>
+                <Tabs tabPosition="left" className="tabs">
+                    <TabPane tab="Home" key="1" className="home-tab">
+                        {this.renderHome()}
+                    </TabPane>
+                    <TabPane tab="Profile" key="2">
+                        {this.renderProfile()}
+                    </TabPane>
+                    <TabPane tab="History" key="3">
+                        {this.renderHistory()}
+                    </TabPane>
+                    <TabPane tab="Donate Now!" key="4">
+                        {this.renderDonateNow()}
+                    </TabPane>
+                </Tabs>
+            </div>
+        );
+    }
+}
+
+export default DonorHome;

--- a/src/components/ngos/NgoHome.js
+++ b/src/components/ngos/NgoHome.js
@@ -1,0 +1,72 @@
+import React, {Component} from 'react';
+import {Tabs} from "antd";
+
+const {TabPane} = Tabs;
+
+class NgoHome extends Component {
+
+    state = {
+        user_id: this.props.session.idToken.payload["cognito:username"],
+        NGO: this.props.session.idToken.payload["custom:custom:NGO"],
+        address: this.props.session.idToken.payload["address"].formatted,
+        lastName: this.props.session.idToken.payload["family_name"],
+        firstName: this.props.session.idToken.payload["given_name"],
+        phoneNumber:this.props.session.idToken.payload["phone_number"]
+    }
+
+    componentDidMount() {
+        console.log(this.state.firstName);
+        console.log(this.state.lastName);
+        console.log(this.state.user_id);
+        console.log(this.state.NGO);
+        console.log(this.state.address);
+        console.log(this.state.phoneNumber);
+
+    }
+    renderHome = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a NGO home page</h2>)
+    }
+
+    renderProfile = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a NGO profile page</h2>)
+    }
+
+    renderNewDonations = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a NGO new donations page</h2>)
+    }
+
+    renderHistory = () => {
+        return (
+            <h2>Hi, {this.state.firstName} {this.state.lastName}!
+                <br/>This is a NGO history page</h2>)
+    }
+    render() {
+        return (
+            <div>
+                <Tabs tabPosition="left">
+                    <TabPane tab="Home" key="1">
+                        {this.renderHome()}
+                    </TabPane>
+                    <TabPane tab="Profile" key="2">
+                        {this.renderProfile()}
+                    </TabPane>
+                    <TabPane tab="NewDonations" key="3">
+                        {this.renderNewDonations()}
+                    </TabPane>
+                    <TabPane tab="History" key="4">
+                        {this.renderHistory()}
+                    </TabPane>
+                </Tabs>
+            </div>
+        );
+    }
+
+}
+
+export default NgoHome;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -3,6 +3,8 @@
 @import "auth/Login.css";
 @import "auth/Register.css";
 @import "TopBar.css";
+@import "donors/DonorHome.css";
+@import "ngos/NgoHome.css";
 
 .App {
   text-align: center;

--- a/src/styles/donors/DonorHome.css
+++ b/src/styles/donors/DonorHome.css
@@ -1,0 +1,7 @@
+.ant-tabs-tab{
+    /*font-weight: bold;*/
+}
+
+.ant-tabs-tab-active{
+    background-color: aliceblue;
+}

--- a/src/styles/ngos/NgoHome.css
+++ b/src/styles/ngos/NgoHome.css
@@ -1,0 +1,7 @@
+.ant-tabs-tab{
+    /*font-weight: bold;*/
+}
+
+.ant-tabs-tab-active{
+    background-color: aliceblue;
+}


### PR DESCRIPTION
1. once logged in, users will be directed to the respective home page (with welcome) instead of the userprofile page. Path is also changed to /home instead of /profile
2. original userProfile component was kept for future reference (in case needed)
3. navigation tabs are added under DonorHome and NgoHome
4. === was used to check if is ngo, now fixed to ==